### PR TITLE
Update main.rs

### DIFF
--- a/examples/14-match-enums/match-enum/src/main.rs
+++ b/examples/14-match-enums/match-enum/src/main.rs
@@ -1,23 +1,23 @@
 enum FileSize {
     Bytes(u64),
-    Kilobytes(u64),
-    Megabytes(u64),
-    Gigabytes(u64),
+    Kilobytes(f64),
+    Megabytes(f64),
+    Gigabytes(f64),
 }
 
 fn format_size(size: u64) -> String {
     let filesize = match size {
         0..=999 => FileSize::Bytes(size),
-        1000..=999_999 => FileSize::Kilobytes(size / 1000),
-        1_000_000..=999_999_999 => FileSize::Megabytes(size / 1_000_000),
-        _ => FileSize::Gigabytes(size / 1_000_000_000),
+        1000..=999_999 => FileSize::Kilobytes(size as f64 / 1000.0),
+        1_000_000..=999_999_999 => FileSize::Megabytes(size as f64 / 1_000_000.0),
+        _ => FileSize::Gigabytes(size as f64 / 1_000_000_000.0),
     };
 
     match filesize {
         FileSize::Bytes(bytes) => format!("{} bytes", bytes),
-        FileSize::Kilobytes(kb) => format!("{:.2} KB", kb as f64 / 1000.0),
-        FileSize::Megabytes(mb) => format!("{:.2} MB", mb as f64 / 1000.0),
-        FileSize::Gigabytes(gb) => format!("{:.2} GB", gb as f64 / 1000.0),
+        FileSize::Kilobytes(kb) => format!("{:.2} KB", kb),
+        FileSize::Megabytes(mb) => format!("{:.2} MB", mb),
+        FileSize::Gigabytes(gb) => format!("{:.2} GB", gb),
     }
 }
 


### PR DESCRIPTION
Dear Teacher,

First,
Maybe I find there's a bug. I think no need to divide by 1000. Because I use the original code to get wrong result.

Second,
In this code, we use integer division to calculate KB, MB, and GB. This causes the result to be rounded down and lose the decimal part's precision.  
To solve this problem, we can convert size into a floating-point number and then perform division so that we can retain the precision of the decimal part.

Hope you have a good day!

sincerely,
Ethan Wang

![error](https://github.com/alfredodeza/rust-structs-types-enums/assets/44759507/36353352-ba45-4b60-8798-211778b89106)
