### PR TITLE
Fixed broken rust-analyze due to missing linked-projects in vscode settings.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Rust",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/rust:0-1-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug",
+            "program": "${workspaceFolder}/<executable file>",
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "rust-analyzer.linkedProjects": [
+        
+        "./examples/1-defining-structs/defining/Cargo.toml" ,
+        "./examples/2-creating-structs/creating/Cargo.toml" ,
+        "./examples/3-associated-functions/associated/Cargo.toml",
+        "./examples/4-methods/methods/Cargo.toml",
+        "./examples/5-more-structs/more/Cargo.toml",
+        "./examples/6-strings/strings/Cargo.toml",
+        "./examples/7-mut-string/manipulating/Cargo.toml",
+        "./examples/8-vectors/vectors/Cargo.toml",
+        "./examples/9-vector-values/values/Cargo.toml",
+        "./examples/10-vector-elements/elements/Cargo.toml",
+        "./examples/11-enums/enums/Cargo.toml",
+        "./examples/12-enum-types/enum-types/Cargo.toml",
+        "./examples/13-option-enum/option-enum/Cargo.toml",
+        "./examples/14-match-enums/match-enum/Cargo.toml",
+        "./examples/15-enums-vectors/enums-vectors/Cargo.toml",
+        "./examples/16-exhaustive/exhaustive/Cargo.toml"
+
+    ]
+}


### PR DESCRIPTION
- Fixed missing vscode workspace settings via linked-projects so rust-analyze can find all projects. This fixes broken workspace in both codespace and local.
- Bumped dev-container image to latest 1-1-bullseye (up from 0-1-bullseye)